### PR TITLE
Add data normalization functionality

### DIFF
--- a/app/people_controller.rb
+++ b/app/people_controller.rb
@@ -1,12 +1,28 @@
+# frozen_string_literal: true
+
 class PeopleController
   def initialize(params)
     @params = params
   end
 
   def normalize
+    normalized_list = process_data.call(**people_params)
+    serialize.call(normalized_list)
   end
 
   private
 
   attr_reader :params
+
+  def people_params
+    params.slice(:order, :dollar_format, :percent_format)
+  end
+
+  def process_data
+    @process_data ||= People::Normalize.new
+  end
+
+  def serialize
+    @serialize ||= People::Serialize.new
+  end
 end

--- a/app/serializers/people/serialize.rb
+++ b/app/serializers/people/serialize.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module People
+  class Serialize
+    DEFAULT_DATE_FORMAT = '%-m/%-d/%Y'
+
+    def call(people_records, date_format = DEFAULT_DATE_FORMAT)
+      people_records.map do |record|
+        record.transform_values! { |value| format_value(value, date_format) }
+        record.values.join(', ')
+      end
+    end
+
+    private
+
+    def format_value(value, date_format)
+      value.is_a?(Date) ? value.strftime(date_format) : value
+    end
+  end
+end

--- a/app/services/people/merge.rb
+++ b/app/services/people/merge.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module People
+  class Merge
+    def call(order_by, *record_lists)
+      order_by = order_by.to_s
+      record_lists.flatten.sort { |a, b| a[order_by] <=> b[order_by] }
+    end
+  end
+end

--- a/app/services/people/normalize.rb
+++ b/app/services/people/normalize.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module People
+  class Normalize
+    NORMALIZED_FIELDS = %w[first_name city birthdate].freeze
+
+    def initialize(merge_lists: People::Merge.new, parse: People::Parse.new)
+      @merge_lists = merge_lists
+      @parse = parse
+    end
+
+    def call(dollar_format:, percent_format:, order:)
+      by_dollar_list = parse.call(dollar_format, '$')
+      by_percent_list = parse.call(percent_format, '%')
+      merged_records = merge_lists.call(order, by_dollar_list, by_percent_list)
+      merged_records.map { |record| record.slice(*NORMALIZED_FIELDS) }
+    end
+
+    private
+
+    attr_reader :merge_lists, :parse
+  end
+end

--- a/app/services/people/parse.rb
+++ b/app/services/people/parse.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module People
+  class Parse
+    CITY_FULL_NAMES = {
+      'LA' => 'Los Angeles',
+      'NYC' => 'New York City'
+    }.freeze
+
+    def call(data, separator)
+      csv = CSV.new(data, col_sep: " #{separator} ", headers: true)
+      csv.read.map { |row| parse_data_row(row) }
+    end
+
+    private
+
+    def parse_data_row(row)
+      row.to_h.tap do |r|
+        r['city'] = full_city_name(r['city'])
+        r['birthdate'] = Date.parse(r['birthdate'])
+      end
+    end
+
+    def full_city_name(city_name)
+      CITY_FULL_NAMES[city_name] || city_name
+    end
+  end
+end

--- a/boot.rb
+++ b/boot.rb
@@ -1,1 +1,6 @@
+# frozen_string_literal: true
+
+require 'csv'
+Dir['./app/services/**/*.rb'].sort.each { |file| require File.expand_path file, __dir__ }
+Dir['./app/serializers/**/*.rb'].sort.each { |file| require File.expand_path file, __dir__ }
 require './app/people_controller.rb'

--- a/spec/serializers/people/serialize_spec.rb
+++ b/spec/serializers/people/serialize_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe People::Serialize do
+  let(:service) { described_class.new }
+
+  let(:people_records) do
+    [
+      {
+        'first_name' => 'Rhiannon',
+        'city' => 'Los Angeles',
+        'birthdate' => Date.new(1974, 4, 30)
+      },
+      {
+        'first_name' => 'Rigoberto',
+        'city' => 'New York City',
+        'birthdate' => Date.new(1962, 1, 5)
+      }
+    ]
+  end
+
+  subject { service.call(people_records) }
+
+  it 'serializes data records' do
+    expect(subject).to eq [
+      'Rhiannon, Los Angeles, 4/30/1974',
+      'Rigoberto, New York City, 1/5/1962'
+    ]
+  end
+end

--- a/spec/services/people/merge_spec.rb
+++ b/spec/services/people/merge_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe People::Merge do
+  describe 'dollar and percent formats sorted by first_name' do
+    let(:service) { described_class.new }
+    let(:records) { [{ 'first_name' => 'Mckayla' }, { 'first_name' => 'Elliot' }] }
+
+    subject { service.call('first_name', records) }
+
+    it 'sorts data records by first_name' do
+      expect(subject).to eq [{ 'first_name' => 'Elliot' }, { 'first_name' => 'Mckayla' }]
+    end
+  end
+end

--- a/spec/services/people/normalize_spec.rb
+++ b/spec/services/people/normalize_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe People::Normalize do
+  let(:service) { described_class.new(merge_lists: merge_lists, parse: parse) }
+
+  let(:merge_lists) { spy(call: records) }
+  let(:parse) { spy call: true }
+
+  let(:records) do
+    [
+      {
+        'birthdate' => Date.new(1947, 05, 04),
+        'city' => 'New York City',
+        'first_name' => 'Elliot',
+        'last_name' => 'Nolan'
+      }
+    ]
+  end
+
+  subject { service.call(dollar_format: double, percent_format: double, order: :first_name) }
+
+  it 'normalizes data' do
+    expect(subject).to eq [
+      {
+        'birthdate' => Date.new(1947, 05, 04),
+        'city' => 'New York City',
+        'first_name' => 'Elliot'
+      }
+    ]
+  end
+end

--- a/spec/services/people/parse_spec.rb
+++ b/spec/services/people/parse_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe People::Parse do
+  let(:service)   { described_class.new }
+
+  let(:data)      { File.read('spec/fixtures/people_by_dollar.txt') }
+  let(:separator) { '$' }
+
+  subject { service.call(data, separator) }
+
+  it 'parses input data' do
+    expect(subject).to eq [
+      {
+        'first_name' => 'Rhiannon',
+        'last_name' => 'Nolan',
+        'city' => 'Los Angeles',
+        'birthdate' => Date.new(1974, 4, 30)
+      },
+      {
+        'first_name' => 'Rigoberto',
+        'last_name' => 'Bruen',
+        'city' => 'New York City',
+        'birthdate' => Date.new(1962, 1, 5)
+      }
+    ]
+  end
+end


### PR DESCRIPTION
This PR adds functionality to allow for:
- reading/parsing people information represented in different formats

- combining the entries from the different formats

- sorting the entries by `first_name`

- formatting each entry to `<first_name>, <city>, <birth_date M/D/YYYY>`